### PR TITLE
Fix stdin is not a tty

### DIFF
--- a/lib/dockly/build_cache/docker.rb
+++ b/lib/dockly/build_cache/docker.rb
@@ -30,7 +30,7 @@ class Dockly::BuildCache::Docker < Dockly::BuildCache::Base
       tar_flags = keep_old_files ? '-xkf' : 'xf'
       container = ::Docker::Container.create(
         'Image' => image.id,
-        'Cmd' => ['/bin/bash', '-lc', [
+        'Cmd' => ['/bin/bash', '-c', [
             "mkdir -p #{File.dirname(output_directory)}",
             '&&',
             "tar #{tar_flags} #{File.join('/', 'host', path)} -C #{File.dirname(output_directory)}"
@@ -87,7 +87,7 @@ class Dockly::BuildCache::Docker < Dockly::BuildCache::Base
   def run_command(command)
     resp = ""
     debug "running command `#{command}` on image #{image.id}"
-    container = image.run(["/bin/bash", "-lc", "cd #{command_directory} && #{command}"])
+    container = image.run(["/bin/bash", "-c", "cd #{command_directory} && #{command}"])
     container.attach(logs: true) { |source,chunk| resp += chunk }
     status = container.wait['StatusCode']
     debug "`#{command}` returned the following output:"


### PR DESCRIPTION
$ docker run 103a74f4671d /bin/bash -lc '/script/arch_version'
    stdin: is not a tty
    Linux_3.16.3-1-ARCH_x86_64
    $ docker run 103a74f4671d /bin/bash -c '/script/arch_version'
    Linux_3.16.3-1-ARCH_x86_64

@nahiluhmot /cc @adamjt @bfulton
