### PR TITLE
Increase wait time and use Container#streaming_logs for reading output

### DIFF
--- a/dockly.gemspec
+++ b/dockly.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w{lib}
   gem.version       = Dockly::VERSION
   gem.add_dependency 'clamp', '~> 0.6'
-  gem.add_dependency 'docker-api', '>= 1.13.1'
+  gem.add_dependency 'docker-api', '>= 1.14.0'
   gem.add_dependency 'dockly-util', '~> 0.0.9'
   gem.add_dependency 'excon'
   gem.add_dependency 'fog', '~> 1.21.0'


### PR DESCRIPTION
Previously, we were reading the output into a variable and then waiting for the status code.  This way, we're sure the process has ended and then reading the logs off from a better location as opposed to attaching to a running container.

This should decrease the read timeout reached.  The only time I'd expect to see it is when the docker daemon itself is halted and the container isn't starting/ending.

@bfulton @nahiluhmot 
