### PR TITLE
Use aws-cli instead of s3cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 
 Although only a specific type of repository may be used, these assumptions allow us to define a simple DSL to describe your repository.
 
+Tool Requirements
+-----------------
+
+To use the generated startup scripts, you'll need to use AWS CLI v1.5.0+
+
 Usage
 -----
 

--- a/snippets/file_diff_docker_import.erb
+++ b/snippets/file_diff_docker_import.erb
@@ -1,7 +1,7 @@
 file_diff_docker_import_fn() {
   s3_path="<%= data[:base_image] %>"
   log "fetch: starting to fetch $s3_path"
-  s3cmd -f get $s3_path - 2> >(log)
+  aws s3 cp --quiet $s3_path - 2> >(log)
   log "fetch: successfully fetched $s3_path"
 }
 

--- a/snippets/get_and_install_deb.erb
+++ b/snippets/get_and_install_deb.erb
@@ -5,7 +5,7 @@ log "fetch: starting to fetch $s3_path"
 for attempt in {1..200}; do
   [[ $worked != 0 ]] || break
   log "fetch: attempt ${attempt} to get $s3_path ..."
-  s3cmd -f get $s3_path $output_path 2> >(log) && worked=0 || (log "fetch: attempt failed, sleeping 30"; sleep 30)
+  aws s3 cp --quiet $s3_path $output_path 2> >(log) && worked=0 || (log "fetch: attempt failed, sleeping 30"; sleep 30)
 done
 [[ $worked != 0 ]] && fatal "fetch: failed to pull deb from S3"
 log "fetch: successfully fetched $s3_path"

--- a/snippets/get_from_s3.erb
+++ b/snippets/get_from_s3.erb
@@ -5,7 +5,7 @@ log "fetch: starting to fetch $s3_path"
 for attempt in {1..200}; do
   [[ $worked != 0 ]] || break
   log "fetch: attempt ${attempt} to get $s3_path ..."
-  s3cmd -f get $s3_path $output_path 2> >(log) && worked=0 || (log "fetch: attempt failed, sleeping 30"; sleep 30)
+  aws s3 cp --quiet $s3_path $output_path 2> >(log) && worked=0 || (log "fetch: attempt failed, sleeping 30"; sleep 30)
 done
 [[ $worked != 0 ]] && fatal "fetch: failed to pull deb from S3"
 log "fetch: successfully fetched $s3_path"

--- a/snippets/s3_diff_docker_import.erb
+++ b/snippets/s3_diff_docker_import.erb
@@ -5,14 +5,14 @@ base_image = "/opt/dockly/base_image.tar"
 s3_diff_docker_import_base_fn() {
   s3_path="<%= data[:base_image] %>"
   log "fetch: starting to fetch $s3_path"
-  s3cmd -f get $s3_path - 2> >(log)
+  aws s3 cp --quiet $s3_path - 2> >(log)
   log "fetch: successfully fetched $s3_path"
 }
 
 s3_diff_docker_import_diff_fn() {
   s3_path="<%= data[:diff_image] %>"
   log "fetch: starting to fetch $s3_path"
-  s3cmd -f get $s3_path - 2> >(log)
+  aws s3 cp --quiet $s3_path - 2> >(log)
   log "fetch: successfully fetched $s3_path"
 }
 

--- a/snippets/s3_docker_import.erb
+++ b/snippets/s3_docker_import.erb
@@ -1,7 +1,7 @@
 s3_docker_import_fn() {
   s3_path="<%= data[:s3_url] %>"
   log "fetch: starting to fetch $s3_path"
-  s3cmd -f get $s3_path - 2> >(log)
+  aws s3 cp --quiet $s3_path - 2> >(log)
   log "fetch: successfully fetched $s3_path"
 }
 

--- a/spec/dockly/bash_builder_spec.rb
+++ b/spec/dockly/bash_builder_spec.rb
@@ -17,7 +17,7 @@ describe Dockly::BashBuilder do
       output = subject.get_and_install_deb(s3_url, deb_path)
       expect(output).to include(s3_url)
       expect(output).to include(deb_path)
-      expect(output).to include("s3cmd -f get")
+      expect(output).to include("aws s3 cp --quiet")
       expect(output).to include("dpkg -i")
     end
   end
@@ -56,7 +56,7 @@ describe Dockly::BashBuilder do
       expect(output).to include(base_image)
       expect(output).to include(diff_image)
       expect(output).to include("cat \"#{diff_image}\"")
-      expect(output).to include("s3cmd -f get")
+      expect(output).to include("aws s3 cp --quiet")
       expect(output).to include("docker import -")
     end
   end
@@ -67,7 +67,7 @@ describe Dockly::BashBuilder do
       output = subject.s3_docker_import(s3_url)
       expect(output).to include(s3_url)
       expect(output).to include("gunzip -c")
-      expect(output).to include("s3cmd -f get")
+      expect(output).to include("aws s3 cp --quiet")
       expect(output).to include("docker import -")
     end
   end
@@ -83,7 +83,7 @@ describe Dockly::BashBuilder do
       expect(output).to include("$(($size - 1024))") # compute file size
       expect(output).to include("head -c $head_size")
       expect(output).to include("gunzip")
-      expect(output).to include("s3cmd -f get")
+      expect(output).to include("aws s3 cp --quiet")
       expect(output).to include("docker import -")
     end
   end


### PR DESCRIPTION
Reconnaissance done by @adamjt

Changed all locations to aws-cli and added a requirement in the README (we were missing one about s3cmd).

Looks like v1.3.0 removed the strict region requirements, and v1.5.0 added support for piping from aws-cli instead of writing to a file.