### PR TITLE
Add missing space.

### DIFF
--- a/snippets/file_diff_docker_import.erb
+++ b/snippets/file_diff_docker_import.erb
@@ -13,7 +13,7 @@ docker_import() {
 
 worked=1
 for attempt in {1..200}; do
-  [[ $worked != 0]] || break
+  [[ $worked != 0 ]] || break
   docker_import && worked=0 || (log "fetch: attempt $attempt failed, sleeping 30"; sleep 30)
 done
 [[ $worked != 0 ]] && fatal "fetch: failed to import diff image"


### PR DESCRIPTION
This was causing the following error:

```
dockly:startup: /opt/dockly/dockly-startup.sh: line 30: unexpected token `newline', conditional binary operator expected
```