### PR TITLE
Allow safe_push_cache to denote what build cache push method to use

### DIFF
--- a/lib/dockly/build_cache/base.rb
+++ b/lib/dockly/build_cache/base.rb
@@ -9,7 +9,7 @@ class Dockly::BuildCache::Base
   dsl_attribute :s3_bucket, :s3_object_prefix, :use_latest,
                 :hash_command, :build_command, :parameter_commands,
                 :base_dir, :command_dir, :output_dir, :tmp_dir,
-                :keep_old_files
+                :keep_old_files, :safe_push_cache
 
   default_value :use_latest, false
   default_value :parameter_commands, {}
@@ -17,6 +17,7 @@ class Dockly::BuildCache::Base
   default_value :output_dir, '.'
   default_value :tmp_dir, Dir.tmpdir
   default_value :keep_old_files, false
+  default_value :safe_push_cache, false
 
   def execute!
     debug "Looking for cache for hash: #{hash_output}"


### PR DESCRIPTION
@adamjt @bfulton @tlunter 

This pull request adds the option to user a different build cache pushing method. Now clients may opt to user `Docker::Image#insert_local` instead of volume mounting, which doesn't work when the Docker host and client aren't on the same machine.