### PR TITLE
Add env directive to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The `docker` DSL is used to define Docker containers. It has the following attri
     - required: `false` -- only required when `import` is not supplied
     - description: the location  of the base image to start building from
     - examples: `paintedfox/ruby`, `registry.example.com/my-custom-image`
-- `env`
+- `build_env`
     - required: `false`
     - description: Hash whose values are environment variables and keys are their values. These variables are only used during build commands, exported images will not contain them.
 - `import`

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ The `docker` DSL is used to define Docker containers. It has the following attri
     - required: `false` -- only required when `import` is not supplied
     - description: the location  of the base image to start building from
     - examples: `paintedfox/ruby`, `registry.example.com/my-custom-image`
+- `env`
+    - required: `false`
+    - description: Hash whose values are environment variables and keys are their values. These variables are only used during build commands, exported images will not contain them.
 - `import`
     - required: `false` -- only required when `registry_import` is not supplied
     - description: the location (url or S3 path) of the base image to start building from

--- a/lib/dockly/docker.rb
+++ b/lib/dockly/docker.rb
@@ -74,6 +74,8 @@ class Dockly::Docker
 
   def cleanup(images)
     info 'Cleaning up intermediate images'
+    images ||= []
+    images = images.compact
     ::Docker::Container.all(:all => true).each do |container|
       image_id = container.json['Image']
       if images.any? { |image| image.id.start_with?(image_id) || image_id.start_with?(image.id) }

--- a/lib/dockly/docker.rb
+++ b/lib/dockly/docker.rb
@@ -28,8 +28,8 @@ class Dockly::Docker
   default_value :s3_bucket, nil
   default_value :s3_object_prefix, ""
 
-  def env(hash = nil)
-    (@env ||= {}).tap { |env| env.merge!(hash) if hash.is_a?(Hash) }
+  def build_env(hash = nil)
+    (@build_env ||= {}).tap { |env| env.merge!(hash) if hash.is_a?(Hash) }
   end
 
   def generate!
@@ -54,7 +54,7 @@ class Dockly::Docker
       info "Successfully pulled #{full_name}"
     end
 
-    images[:two] = add_env(images[:one])
+    images[:two] = add_build_env(images[:one])
     images[:three] = add_git_archive(images[:two])
     images[:four] = run_build_caches(images[:three])
     build_image(images[:four])
@@ -149,12 +149,12 @@ class Dockly::Docker
     image
   end
 
-  def add_env(image)
-    return image if env.empty?
-    info "Setting the following environment variables in the docker image: #{env.keys}"
+  def add_build_env(image)
+    return image if build_env.empty?
+    info "Setting the following environment variables in the docker image: #{build_env.keys}"
     dockerfile = [
       "FROM #{image.id}",
-      *env.map { |key, val| "ENV #{key.to_s.shellescape}=#{val.to_s.shellescape}" }
+      *build_env.map { |key, val| "ENV #{key.to_s.shellescape}=#{val.to_s.shellescape}" }
     ].join("\n")
     out_image = ::Docker::Image.build(dockerfile)
     info "Successfully set the environment variables in the dockerfile"

--- a/spec/dockly/build_cache/docker_spec.rb
+++ b/spec/dockly/build_cache/docker_spec.rb
@@ -156,7 +156,7 @@ describe Dockly::BuildCache::Docker, :docker do
     context "when parameter command returns successfully" do
       let(:command) { "uname -r" }
       it 'returns the output of the parameter_command' do
-        expect(build_cache.parameter_output(command)).to match(/\A3\.\d+\.\d+-\d+-ARCH\Z/)
+        expect(build_cache.parameter_output(command)).to match(/\A3\.\d{2}\.\d-\d{2}-ARCH\Z/)
       end
     end
 

--- a/spec/dockly/build_cache/docker_spec.rb
+++ b/spec/dockly/build_cache/docker_spec.rb
@@ -7,7 +7,7 @@ describe Dockly::BuildCache::Docker, :docker do
       git_archive '/app'
     end
   end
-  let(:image) { ::Docker::Image.build('from ubuntu') }
+  let(:image) { ::Docker::Image.build('from ubuntu:14.04') }
 
   before do
     build_cache.s3_bucket 'lol'
@@ -127,7 +127,7 @@ describe Dockly::BuildCache::Docker, :docker do
   end
 
   describe '#copy_output_dir' do
-    let(:container) { Docker::Container.create('Image' => 'ubuntu', 'Cmd' => %w[true]) }
+    let(:container) { Docker::Container.create('Image' => 'ubuntu:14.04', 'Cmd' => %w[true]) }
     let(:file) { build_cache.copy_output_dir(container) }
     let(:hash) { 'this_really_unique_hash' }
     let(:path) { file.path }

--- a/spec/dockly/build_cache/docker_spec.rb
+++ b/spec/dockly/build_cache/docker_spec.rb
@@ -100,7 +100,7 @@ describe Dockly::BuildCache::Docker, :docker do
 
   describe '#hash_output' do
     let(:output) {
-      "682aa2a07693cc27756eee9751db3903  /etc/vim/vimrc"
+      "b458e7b28b9bc2d04bd5a3fd0f8d777e  /etc/vim/vimrc"
     }
 
     context "when hash command returns successfully" do

--- a/spec/dockly/build_cache/docker_spec.rb
+++ b/spec/dockly/build_cache/docker_spec.rb
@@ -156,7 +156,7 @@ describe Dockly::BuildCache::Docker, :docker do
     context "when parameter command returns successfully" do
       let(:command) { "uname -r" }
       it 'returns the output of the parameter_command' do
-        expect(build_cache.parameter_output(command)).to match(/\A3\.\d{2}\.\d-\d{2}-general\Z/)
+        expect(build_cache.parameter_output(command)).to match(/\A3\.\d{2}\.\d-\d{2}-generic\Z/)
       end
     end
 

--- a/spec/dockly/build_cache/docker_spec.rb
+++ b/spec/dockly/build_cache/docker_spec.rb
@@ -7,7 +7,7 @@ describe Dockly::BuildCache::Docker, :docker do
       git_archive '/app'
     end
   end
-  let(:image) { ::Docker::Image.build('from base') }
+  let(:image) { ::Docker::Image.build('from ubuntu') }
 
   before do
     build_cache.s3_bucket 'lol'
@@ -127,7 +127,7 @@ describe Dockly::BuildCache::Docker, :docker do
   end
 
   describe '#copy_output_dir' do
-    let(:container) { Docker::Container.create('Image' => 'base', 'Cmd' => %w[true]) }
+    let(:container) { Docker::Container.create('Image' => 'ubuntu', 'Cmd' => %w[true]) }
     let(:file) { build_cache.copy_output_dir(container) }
     let(:hash) { 'this_really_unique_hash' }
     let(:path) { file.path }

--- a/spec/dockly/build_cache/docker_spec.rb
+++ b/spec/dockly/build_cache/docker_spec.rb
@@ -156,7 +156,7 @@ describe Dockly::BuildCache::Docker, :docker do
     context "when parameter command returns successfully" do
       let(:command) { "uname -r" }
       it 'returns the output of the parameter_command' do
-        expect(build_cache.parameter_output(command)).to match(/\A3\.\d{2}\.\d-\d-ARCH\Z/)
+        expect(build_cache.parameter_output(command)).to match(/\A3\.\d+\.\d+-\d+-ARCH\Z/)
       end
     end
 

--- a/spec/dockly/build_cache/docker_spec.rb
+++ b/spec/dockly/build_cache/docker_spec.rb
@@ -156,7 +156,7 @@ describe Dockly::BuildCache::Docker, :docker do
     context "when parameter command returns successfully" do
       let(:command) { "uname -r" }
       it 'returns the output of the parameter_command' do
-        expect(build_cache.parameter_output(command)).to match(/\A3\.\d{2}\.\d-\d{2}-ARCH\Z/)
+        expect(build_cache.parameter_output(command)).to match(/\A3\.\d{2}\.\d-\d{2}-general\Z/)
       end
     end
 

--- a/spec/dockly/deb_spec.rb
+++ b/spec/dockly/deb_spec.rb
@@ -52,7 +52,7 @@ describe Dockly::Deb do
         subject.create_package!
       end
 
-      it 'exports the foreman to the deb', :cur do
+      it 'exports the foreman to the deb' do
         expect(contents).to match(/upstart-foreman/)
         expect(contents).to match(/systemd-foreman/)
       end

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -255,7 +255,8 @@ describe Dockly::Docker do
         subject.instance_eval do
           import 'https://s3.amazonaws.com/swipely-pub/docker-export-ubuntu-latest.tgz'
           git_archive '.'
-          build "run touch /it_worked"
+          build_env 'TEST_FILE' => 'it_worked'
+          build "run touch $TEST_FILE"
           repository 'dockly_test'
           build_dir 'build/docker'
           cleanup_images false

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -277,7 +277,7 @@ describe Dockly::Docker do
           paths.should include('sbin/init')
           paths.should include('lib/dockly.rb')
           paths.should include('it_worked')
-        }.to change { ::Docker::Image.all(:all => true).length }.by(3)
+        }.to change { ::Docker::Image.all(:all => true).length }.by(4)
       end
     end
 

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -148,7 +148,7 @@ describe Dockly::Docker do
   end
 
   describe "#export_image", :docker do
-    let(:image) { Docker::Image.create('fromImage' => 'ubuntu') }
+    let(:image) { Docker::Image.create('fromImage' => 'ubuntu:14.04') }
 
     context "with a registry export" do
       let(:registry) { double(:registry) }

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -148,7 +148,7 @@ describe Dockly::Docker do
   end
 
   describe "#export_image", :docker do
-    let(:image) { Docker::Image.create('fromImage' => 'base') }
+    let(:image) { Docker::Image.create('fromImage' => 'ubuntu') }
 
     context "with a registry export" do
       let(:registry) { double(:registry) }


### PR DESCRIPTION
**FEATURE**

@tlunter @adamjt @bfulton 

Add a directive to the `docker` DSL called `env`. It allows users to specify environment variables to be set for the build, but these will not be set in the generated image. Usage:

```ruby
docker :sweet_docker do
  env 'SOME_VARIABLE' => 'value', 'OTHER_VARIABLE' => 12
end
```

Note that all keys and values will be shell escaped.