### PR TITLE
Backport safe_push_cache to 1.x.x stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ In addition to the above attributes, `deb` has the following references:
     - required: `false`
     - default: `nil`
     - class: `Dockly::Foreman`
-    - description: any Foreman scripts used in the deb
+    - description: any Foreman scripts used in the deb.
 
 `rpm`
 -----

--- a/lib/dockly/build_cache/base.rb
+++ b/lib/dockly/build_cache/base.rb
@@ -9,7 +9,7 @@ class Dockly::BuildCache::Base
   dsl_attribute :s3_bucket, :s3_object_prefix, :use_latest,
                 :hash_command, :build_command, :parameter_commands,
                 :base_dir, :command_dir, :output_dir, :tmp_dir,
-                :keep_old_files
+                :keep_old_files, :safe_push_cache
 
   default_value :use_latest, false
   default_value :parameter_commands, {}
@@ -17,6 +17,7 @@ class Dockly::BuildCache::Base
   default_value :output_dir, '.'
   default_value :tmp_dir, Dir.tmpdir
   default_value :keep_old_files, false
+  default_value :safe_push_cache, false
 
   def execute!
     debug "Looking for cache for hash: #{hash_output}"

--- a/lib/dockly/deb.rb
+++ b/lib/dockly/deb.rb
@@ -10,7 +10,7 @@ class Dockly::Deb
                 :post_uninstall, :s3_bucket, :files, :app_user, :vendor
 
   dsl_class_attribute :docker, Dockly::Docker
-  dsl_class_attribute :foreman, Dockly::Foreman
+  dsl_class_attribute :foreman, Dockly::Foreman, type: Array
 
   default_value :version, '0.0'
   default_value :release, '0'
@@ -127,14 +127,14 @@ private
   end
 
   def add_foreman(package)
-    return if foreman.nil?
-    info "adding foreman export"
-    foreman.create!
-    package.attributes[:prefix] = foreman.init_dir
-    Dir.chdir(foreman.build_dir) do
-      package.input('.')
+    return if (foreman || []).empty?
+    foreman.each do |fore|
+      info "adding foreman export '#{fore.name}'"
+      fore.create!
+      package.attributes[:prefix] = fore.init_dir
+      Dir.chdir(fore.build_dir) { package.input('.') }
+      package.attributes[:prefix] = nil
     end
-    package.attributes[:prefix] = nil
   end
 
   def add_files(package)

--- a/spec/dockly/deb_spec.rb
+++ b/spec/dockly/deb_spec.rb
@@ -25,23 +25,36 @@ describe Dockly::Deb do
       end
     end
 
-    context 'when it has a foreman export' do
+    context 'when it has foreman exports' do
+      let(:contents) { `dpkg --contents #{filename}` }
+
       before do
         subject.foreman do
-          name 'foreman'
-          init_dir '/etc/systemd/system'
+          name 'systemd-foreman'
           build_dir 'build/foreman'
+          init_dir '/etc/systemd/system'
           procfile File.join(File.dirname(__FILE__), '..', 'fixtures', 'Procfile')
           user 'root'
           type 'systemd'
           prefix '/bin/sh'
         end
+
+        subject.foreman do
+          name 'upstart-foreman'
+          build_dir 'build/foreman'
+          init_dir '/etc/systemd/system'
+          procfile File.join(File.dirname(__FILE__), '..', 'fixtures', 'Procfile')
+          user 'root'
+          type 'upstart'
+          prefix '/bin/sh'
+        end
+
+        subject.create_package!
       end
 
-      it 'export the foreman to the deb' do
-        subject.create_package!
-        `dpkg --contents #{filename}`
-            .lines.grep(/foreman/).should_not be_empty
+      it 'exports the foreman to the deb', :cur do
+        expect(contents).to match(/upstart-foreman/)
+        expect(contents).to match(/systemd-foreman/)
       end
     end
 


### PR DESCRIPTION
@tlunter 

These changes were applied via a manually edited `git diff` between v2.0.0 and v2.1.0. The diff needed to be manually edited to remove the snippets files that are only in v2.x.x and the version diff. Otherwise, all of the changes are consistent.