### PR TITLE
Remove bad imports

### DIFF
--- a/snippets/s3_diff_docker_import.erb
+++ b/snippets/s3_diff_docker_import.erb
@@ -35,7 +35,9 @@ docker_import() {
 }
 
 remove_bad_imports() {
+  log "removing bad imports"
   docker images | grep \<none | awk '{ print $3 }' | xargs docker rmi
+  log "bad import removed"
 }
 
 worked=1

--- a/snippets/s3_diff_docker_import.erb
+++ b/snippets/s3_diff_docker_import.erb
@@ -34,6 +34,10 @@ docker_import() {
   docker import - $repo:$tag > >(log) 2>&1 || fatal "docker failed to import"
 }
 
+remove_bad_imports() {
+  docker images | grep \<none | awk '{ print $3 }' | xargs docker rmi
+}
+
 worked=1
 for attempt in {1..200}; do
   [[ $worked != 0 ]] || break
@@ -46,6 +50,7 @@ worked=1
 for attempt in {1..200}; do
   [[ $worked != 0 ]] || break
   stream_image | docker_import && worked=0 || (log "fetch: attempt $attempt failed, sleeping 30"; sleep 30)
+  [[ $worked != 0 ]] && remove_bad_imports
 done
 [[ $worked != 0 ]] && fatal "fetch: failed to import diff image"
 log "fetch: successfully imported diff image"


### PR DESCRIPTION
When an image is imported but the upstream pipe has failed, we should remove those imported images.

@bfulton 