### PR TITLE
Add content hashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ rvm:
     - 2.0
     - 2.1
     - 2.2
-script: git pull origin --tag && CI=true bundle exec rake
+script:
+  - git fetch --tags
+  - CI=true bundle exec rake
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq rpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 rvm:
-    - 1.9.3
-    - 2.0.0
-script: CI=true bundle exec rake
+    - 1.9
+    - 2.0
+    - 2.1
+    - 2.2
+script: git pull origin --tag && CI=true bundle exec rake
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq rpm

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,11 @@ require 'rake'
 require 'dockly'
 require 'rspec/core/rake_task'
 require 'cane/rake_task'
+require 'pry'
+
+task :shell do
+  Pry.start(Dockly)
+end
 
 task :default => [:spec, :quality]
 

--- a/dockly.gemspec
+++ b/dockly.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'foreman'
   gem.add_dependency 'fpm', '~> 1.2.0'
   gem.add_dependency 'grit'
+  gem.add_dependency 'rugged'
   gem.add_development_dependency 'cane'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'

--- a/lib/dockly.rb
+++ b/lib/dockly.rb
@@ -4,6 +4,7 @@ require 'dockly/util/git'
 require 'fog'
 require 'foreman/cli_fix'
 require 'foreman/export/base_fix'
+require 'rugged'
 
 module Dockly
   attr_reader :instance, :git_sha

--- a/lib/dockly.rb
+++ b/lib/dockly.rb
@@ -16,6 +16,7 @@ module Dockly
   autoload :BuildCache, 'dockly/build_cache'
   autoload :Docker, 'dockly/docker'
   autoload :Deb, 'dockly/deb'
+  autoload :History, 'dockly/history'
   autoload :Rpm, 'dockly/rpm'
   autoload :TarDiff, 'dockly/tar_diff'
 

--- a/lib/dockly/history.rb
+++ b/lib/dockly/history.rb
@@ -1,0 +1,64 @@
+# This module contains logic to find matching content hash for a given commit.
+module Dockly::History
+  module_function
+
+  ASCII_FILE_SEP = 28.chr
+  ASCII_RECORD_SEP = 30.chr
+
+  TAG_PREFIX = 'dockly-'
+
+  def push_content_tag!
+    fail 'An SSH agent must be running to push the tag' if ENV['SSH_AGENT_PID'].nil?
+    refs = ["refs/tags/#{content_tag}"]
+    repo.remotes.each do |remote|
+      username = remote.url.split('@').first
+      creds = Rugged::Credentials::SshKeyFromAgent.new(username: username)
+      remote.push(refs, credentials: creds)
+    end
+  end
+
+  def write_content_tag!
+    repo.tags.create(content_tag, repo.head.target_id, true)
+  end
+
+  def duplicate_build?
+    !duplicate_build_sha.nil?
+  end
+
+  def duplicate_build_sha
+    return @duplicate_build_sha if @duplicate_build_sha
+    sha = tags[content_tag]
+    @duplicate_build_sha = sha unless sha == repo.head.target_id
+  end
+
+  def tags
+    @tags ||= Hash.new do |hash, key|
+      tag = repo.tags[key]
+      hash[key] = tag.target_id if tag
+    end
+  end
+
+  def content_tag
+    @content_tag ||= TAG_PREFIX + content_hash_for(ls_files)
+  end
+
+  def ls_files
+    repo.head.target.tree.walk(:preorder)
+      .map { |root, elem| [root, elem[:name]].compact.join }
+      .select(&File.method(:file?))
+  end
+
+  def content_hash_for(paths)
+    paths.sort.each_with_object(Digest::SHA384.new) do |path, hash|
+      next unless File.exist?(path)
+      mode = File::Stat.new(path).mode
+      data = File.read(path)
+      str = [path, mode, data].join(ASCII_RECORD_SEP.chr) + ASCII_FILE_SEP.chr
+      hash.update(str)
+    end.hexdigest
+  end
+
+  def repo
+    @repo ||= Rugged::Repository.discover('.')
+  end
+end

--- a/spec/dockly/history_spec.rb
+++ b/spec/dockly/history_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe Dockly::History do
+  describe '#duplicate_build?' do
+    before { allow(subject).to receive(:duplicate_build_sha).and_return(sha) }
+
+    context 'when the duplicate build sha is not present' do
+      let(:sha) { nil }
+
+      it 'returns false' do
+        expect(subject).to_not be_duplicate_build
+      end
+    end
+
+    context 'when the duplicate build sha is present' do
+      let(:sha) { 'DEADBEEF' }
+
+      it 'returns true' do
+        expect(subject).to be_duplicate_build
+      end
+    end
+  end
+
+  describe '#duplicate_build_sha' do
+    let(:content_tag) { 'dockly-FAKE-CONTENT-HASH' }
+
+    before { allow(subject).to receive(:content_tag).and_return(content_tag) }
+
+    context 'when there is not a commit with a matching content hash' do
+      it 'returns nil' do
+        expect(subject.duplicate_build_sha).to be(nil)
+      end
+    end
+
+    context 'when there is a commit with a matching content hash' do
+      let(:sha) { 'dockly-FAKE-SHA' }
+      let(:key) { content_tag }
+
+      before { subject.tags[key] = sha }
+      after { subject.tags.delete(key) }
+
+      it 'returns that commit' do
+        expect(subject.duplicate_build_sha).to eq(sha)
+      end
+    end
+  end
+
+  describe '#tags' do
+    let(:expected) do
+      {
+        'v1.4.0' => '708b4f1bd7846c258e2151e34f8f746b399ee6fb',
+        'v1.4.2' => '20b62fa084ac903a8753cfc7939c7e31c86761d2',
+        'v1.4.3' => '8eac23450975d91f0aa4c62c6985ec4f4ce7594f'
+      }
+    end
+
+    it 'returns a Hash of the git tags' do
+      expected.each do |tag, oid|
+        expect(subject.tags[tag]).to include(oid)
+      end
+    end
+  end
+
+  describe '#ls_files' do
+    let(:files) { subject.ls_files }
+
+    it 'returns the files checked into the repo' do
+      expect(files).to be_a(Array)
+      expect(files).to include('dockly.gemspec')
+      expect(files).to include('lib/dockly.rb')
+      expect(files).to include('spec/dockly/aws/s3_writer_spec.rb')
+    end
+  end
+
+  describe '#content_hash_for' do
+    context 'when two hashes are compared' do
+      let(:hash_one) { subject.content_hash_for(%w(dockly.gemspec Gemfile)) }
+      let(:hash_two) { subject.content_hash_for(%w(lib/dockly.rb LICENSE.txt)) }
+
+      it 'creates a unique hash for the given paths' do
+        expect(hash_one).to_not eq(hash_two)
+      end
+    end
+
+    context 'when the paths are in a different order' do
+      let(:hash_one) { subject.content_hash_for(%w(dockly.gemspec Gemfile)) }
+      let(:hash_two) { subject.content_hash_for(%w(Gemfile dockly.gemspec)) }
+
+      it 'still creates the same hash' do
+        expect(hash_one).to eq(hash_two)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## FEATURE: Content Hashing

@adamjt @bfulton @tlunter 

Content hashing computes a hash of the files checked into git. Using that hash, we can determine if two commits are equivalent (in terms of their content). If two commits are equivalent, then we can use the docker image built for one of the commits in place of the other one.

### Specific changes

* Update the versions of ruby that run on travis to include `1.9`, `2.0`, `2.1`, and `2.2`
* Pull git tags on travis
* Add the `rake shell` development command that starts a `Pry` console in the context of the `Dockly` module
* Install `Rugged` to use advanced git features
* Add the `Dockly::History` module that hashes content and checks if a given commit has a duplicate parent
* Add logic to `Dockly::Deb`, `Dockly::Docker`, and `Dockly::Rpm` to copy pre-built assets
* Add the `bundle exec rake dockly:build_or_copy_all` command that acts just like `dockly:build_all`, with the exception that it checks if this code has already been built first, copying the assets if so instead of re-building them

### How to use it

Execute `bundle exec rake dockly:build_or_copy_all` in place of `bundle exec rake dockly:build_all`.