### PR TITLE
Fix Dockly::History#push_content_tag!

### DIFF
--- a/lib/dockly/history.rb
+++ b/lib/dockly/history.rb
@@ -8,7 +8,7 @@ module Dockly::History
   TAG_PREFIX = 'dockly-'
 
   def push_content_tag!
-    fail 'An SSH agent must be running to push the tag' if ENV['SSH_AGENT_PID'].nil?
+    fail 'An SSH agent must be running to push the tag' if ENV['SSH_AUTH_SOCK'].nil?
     refs = ["refs/tags/#{content_tag}"]
     repo.remotes.each do |remote|
       username = remote.url.split('@').first


### PR DESCRIPTION
@tlunter 

Before, we were looking for the $SSH_AGENT_PID, which only exists when
the SSH agent is on the same host the commands are running on. However,
this doesn't exist when using remote ssh agent forwarding. This commit
instead inspects the correct environment variable, $SSH_AUTH_SOCK,
before failing.