### PR TITLE
Only import the base image when it is needed.

### DIFF
--- a/lib/dockly/docker.rb
+++ b/lib/dockly/docker.rb
@@ -168,10 +168,19 @@ class Dockly::Docker
   end
 
   def import_base(docker_tar)
-    info "importing the docker image from #{docker_tar}"
-    image = ::Docker::Image.import(docker_tar)
-    info "imported initial docker image: #{image.id}"
-    image
+    repo = "#{name}-base"
+    tag = "dockly-#{Dockly::VERSION}-#{File.basename(docker_tar).split('.').first}"
+    info "looking for imported base image with tag: #{tag}"
+    image = Docker::Image.all.find { |img| img.info['RepoTags'].include?("#{repo}:#{tag}") }
+    if image
+      info "found imported base image: #{image.id}"
+      image
+    else
+      info "could not find image with tag #{tag}, importing the docker image from #{docker_tar}"
+      image = ::Docker::Image.import(docker_tar, 'repo' => repo, 'tag' => tag)
+      info "imported initial docker image: #{image.id}"
+      image
+    end
   end
 
   def add_build_env(image)

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -101,6 +101,15 @@ describe Dockly::Docker do
       subject.export_image(images.last)
       expect(File.exist?('build/docker/test_docker-image.tgz')).to be_true
     end
+
+    context 'when the image has already been imported' do
+      before { images << subject.import_base(docker_file) }
+
+      it 'does not reimport the image' do
+        expect(Docker::Image).to_not receive(:import)
+        subject.import_base(docker_file)
+      end
+    end
   end
 
   describe '#fetch_import' do

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -85,6 +85,10 @@ describe Dockly::Docker do
         end
       end
       images << subject.import_base(subject.ensure_tar(docker_file))
+      expect(Docker::Image.all).to be_any do |image|
+        image.info['RepoTags']
+          .include?("my-app-base:dockly-#{Dockly::VERSION}-docker-export-ubuntu-latest")
+      end
       expect(images.last).to_not be_nil
       expect(images.last.id).to_not be_nil
 


### PR DESCRIPTION
@tlunter @bfulton @adamjt 

This is accomplished by giving each import a unique tag, and checking
for the tag before importing.