### PR TITLE
Lessen restriction for dockly-util

### DIFF
--- a/dockly.gemspec
+++ b/dockly.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Dockly::VERSION
   gem.add_dependency 'clamp', '~> 0.6'
   gem.add_dependency 'docker-api', '>= 1.14.0'
-  gem.add_dependency 'dockly-util', '~> 0.0.9'
+  gem.add_dependency 'dockly-util', '>= 0.0.9', '< 1.0'
   gem.add_dependency 'excon'
   gem.add_dependency 'aws-sdk', '~> 2.0'
   gem.add_dependency 'foreman'


### PR DESCRIPTION
@nahiluhmot

Needed to be able to install alongside aerosol v1.2.0 which uses dockly-util v0.1.0.