### PR TITLE
Just shell out for the archive (helps long filenames)

### DIFF
--- a/lib/dockly.rb
+++ b/lib/dockly.rb
@@ -5,6 +5,7 @@ require 'foreman/cli_fix'
 require 'foreman/export/base_fix'
 require 'rugged'
 require 'aws-sdk'
+require 'open3'
 
 module Dockly
   LOAD_FILE = 'dockly.rb'

--- a/spec/dockly/util/git_spec.rb
+++ b/spec/dockly/util/git_spec.rb
@@ -43,7 +43,7 @@ describe Dockly::Util::Git do
       let(:prefix) { '/' + ('a' * 255) }
       it 'exhibits the tar extended headers' do
         subject.archive(subject.sha, prefix, io)
-        expect(io.string.include?('path=')).to be true
+        expect(io.string.include?("path=#{prefix}")).to be true
       end
     end
   end

--- a/spec/dockly/util/git_spec.rb
+++ b/spec/dockly/util/git_spec.rb
@@ -28,10 +28,22 @@ describe Dockly::Util::Git do
     it 'archives the current directory into the given IO' do
       subject.archive(subject.sha, prefix, io)
       reader.each do |entry|
-        expect(entry.full_name).to start_with(prefix)
-        orig = entry.full_name.gsub(/\A#{prefix}\//, '')
-        expect(File.exist?(orig)).to be_true
-        expect(entry.read).to eq(File.read(orig)) if orig.end_with?('.rb')
+        if entry.full_name == 'pax_global_header'
+          expect(entry.header.typeflag).to eq('g')
+        else
+          expect(entry.full_name).to start_with(prefix)
+          orig = entry.full_name.gsub(/\A#{prefix}/, '.')
+          expect(File.exist?(orig)).to be_true
+          expect(entry.read).to eq(File.read(orig)) if orig.end_with?('.rb')
+        end
+      end
+    end
+
+    context 'with a really long prefix' do
+      let(:prefix) { '/' + ('a' * 255) }
+      it 'exhibits the tar extended headers' do
+        subject.archive(subject.sha, prefix, io)
+        expect(io.string.include?('path=')).to be true
       end
     end
   end


### PR DESCRIPTION
@nahiluhmot @bfulton

Long filenames in the repo (files for VCR mostly) can get to be over 255 characters and will not work with rubygems ustar-only tar writer.