### PR TITLE
ignore nil RepoTags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: ruby
 rvm:
-    - 1.9
-    - 2.0
-    - 2.1
-    - 2.2
+  - 1.9
+  - 2.0
+  - 2.1
+  - 2.2
 script:
   - git fetch --tags
   - CI=true bundle exec rake
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq rpm
-  - gem install bundler
-
+  - gem install bundler -v 1.17.3

--- a/lib/dockly/docker.rb
+++ b/lib/dockly/docker.rb
@@ -177,7 +177,9 @@ class Dockly::Docker
     repo = "#{name}-base"
     tag = "dockly-#{Dockly::VERSION}-#{File.basename(import).split('.').first}"
     info "looking for imported base image with tag: #{tag}"
-    image = Docker::Image.all.find { |img| img.info['RepoTags'].include?("#{repo}:#{tag}") }
+    image = Docker::Image.all.find do |img|
+      img.info['RepoTags'] && img.info['RepoTags'].include?("#{repo}:#{tag}")
+    end
     if image
       info "found imported base image: #{image.id}"
       image

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -147,7 +147,7 @@ describe Dockly::Docker do
       end
 
       context 'and it points to a non-S3 url' do
-        let(:url) { 'http://www.html5zombo.com' }
+        let(:url) { 'http://html5zombo.com' }
 
        before { subject.tag 'yolo' }
 


### PR DESCRIPTION
https://jenkins.internal.upserve.com/job/app.relbot-2000/66/console

Can get nil RepoTags which is breaking the Jenkins build for Relbot

```
[6] pry(main)> Docker::Image.all.select { |img| img.info['RepoTags'] == nil }
=> [#<Docker::Image:0x007f8e80092f98
  @connection=
   #<Docker::Connection:0x007f8e7f9aed80
    @options={:socket=>"/var/run/docker.sock"},
    @url="unix:///">,
  @id=
   "sha256:b7b28af77ffec6054d13378df4fdf02725830086c7444d9c278af25312aa39b9",
  @info=
   {"Containers"=>-1,
    "Created"=>1562883652,
    "Labels"=>nil,
    "ParentId"=>"",
    "RepoDigests"=>
     ["alpine@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998"],
    "RepoTags"=>nil,
    "SharedSize"=>-1,
    "Size"=>5581746,
    "VirtualSize"=>5581746,
    "id"=>
     "sha256:b7b28af77ffec6054d13378df4fdf02725830086c7444d9c278af25312aa39b9"}>]
```
