### PR TITLE
Tag all registry-built images as `repo:latest`, raise when image fails to push to registry

### DIFF
--- a/lib/dockly/bash_builder.rb
+++ b/lib/dockly/bash_builder.rb
@@ -26,6 +26,6 @@ module Dockly
     generate_snippet_for :registry_import, [:repo, :tag], { :tag => "latest" }
     generate_snippet_for :auth_ecr, [:server_address]
 
-    generate_snippet_for :docker_tag_latest, [:repo, :tag]
+    generate_snippet_for :docker_tag_latest, [:repo, :tag, :new_name]
   end
 end

--- a/lib/dockly/deb.rb
+++ b/lib/dockly/deb.rb
@@ -226,12 +226,13 @@ private
         if registry.is_a?(Dockly::Docker::ECR)
           scripts << bb.auth_ecr(registry.server_address)
         end
+
         scripts << bb.registry_import(docker.repo, docker.tag)
+        scripts << bb.docker_tag_latest(docker.repo, docker.tag, docker.name)
       else
         scripts += collect_non_registry_scripts(bb)
       end
     end
-
     scripts.join("\n")
   end
 
@@ -252,7 +253,8 @@ private
         scripts << bb.s3_docker_import(docker.s3_url, docker.name, docker.tag)
       end
     end
-    scripts << bb.docker_tag_latest(docker.repo, docker.tag)
+
+    scripts << bb.docker_tag_latest(docker.repo, docker.tag, docker.repo)
   end
 
   def add_startup_script(package, startup_script = "dockly-startup.sh")

--- a/lib/dockly/docker.rb
+++ b/lib/dockly/docker.rb
@@ -339,7 +339,11 @@ class Dockly::Docker
 
     raise "Could not find image after authentication" if image.nil?
 
-    image.push(registry.to_h, :registry => registry.server_address)
+    image.push(registry.to_h, :registry => registry.server_address) do |resp|
+      if resp.include?('errorDetail')
+        raise "Error pushing to registry: #{resp}"
+      end
+    end
   end
 
   def fetch_import

--- a/snippets/docker_tag_latest.erb
+++ b/snippets/docker_tag_latest.erb
@@ -1,3 +1,3 @@
 <% if data[:tag] %>
-docker tag <%= data[:repo] %>:<%= data[:tag] %> <%= data[:repo] %>:latest
+docker tag <%= data[:repo] %>:<%= data[:tag] %> <%= data[:new_name] %>:latest
 <% end %>

--- a/spec/dockly/bash_builder_spec.rb
+++ b/spec/dockly/bash_builder_spec.rb
@@ -32,8 +32,8 @@ describe Dockly::BashBuilder do
 
     context "when there is a tag" do
       it "tags the repo:tag as repo:latest" do
-        output = subject.docker_tag_latest("test_repo", "a_tag")
-        expect(output).to include("docker tag test_repo:a_tag test_repo:latest")
+        output = subject.docker_tag_latest("registry/test_repo", "a_tag", "test_repo")
+        expect(output).to include("docker tag registry/test_repo:a_tag test_repo:latest")
       end
     end
   end

--- a/spec/dockly/docker_spec.rb
+++ b/spec/dockly/docker_spec.rb
@@ -313,6 +313,103 @@ describe Dockly::Docker do
     end
   end
 
+  describe '#push_to_registry', :docker do
+    let(:image) { Docker::Image.create('fromImage' => 'ubuntu:14.04') }
+    let(:ecr) { double(:ecr) }
+
+    context 'when there is no registry' do
+      it 'raises' do
+        expect(subject.registry).to eq(nil)
+
+        expect { subject.push_to_registry(image) }.to raise_error(/No registry/)
+      end
+    end
+
+    context 'when there is a registry' do
+      before do
+        subject.instance_variable_set(:"@ecr", ecr)
+
+        allow(ecr)
+          .to receive(:server_address)
+          .and_return('server_address')
+
+        expect(subject.registry).to eq(ecr)
+      end
+
+      context "that can't be authenticated to" do
+        before do
+          allow(ecr)
+            .to receive(:authenticate!)
+            .and_raise
+        end
+
+        it 'raises' do
+          expect { subject.push_to_registry(image) }
+            .to raise_error(StandardError)
+        end
+      end
+
+      context 'that can be authenticated to' do
+        before do
+          allow(ecr).to receive(:authenticate!)
+
+          allow(Docker::Image)
+            .to receive(:all)
+            .with(all: true)
+            .and_return(available_images)
+        end
+
+        context "but the image isn't found" do
+          let(:available_images) { [] }
+
+          it 'raises' do
+            expect { subject.push_to_registry(image) }
+              .to raise_error(/Could not find image after authentication/)
+          end
+        end
+
+        context 'and the image is found' do
+          let(:available_images) { [image] }
+          let(:error_msg) do
+            <<-EOF
+              {"errorDetail":{"message":"name unknown: The repository with name 'repository'
+              does not exist in the registry with id 'accoundid'"},"error":"name unknown:
+              The repository with name 'repository' does not exist in the registry with id 'accountid'"}
+            EOF
+          end
+
+          before do
+            allow(ecr)
+              .to receive(:to_h)
+              .and_return({})
+          end
+
+          context 'but the push to the registry fails' do
+            before do
+              allow(image)
+                .to receive(:push)
+                .and_yield(error_msg)
+            end
+
+            it 'raises' do
+              expect { subject.push_to_registry(image) }
+                .to raise_error(/Error pushing to registry/)
+            end
+          end
+
+          context 'and the push to the registry succeeds' do
+            before { allow(image).to receive(:push) }
+
+            it 'passes' do
+              expect(subject.push_to_registry(image))
+                .not_to raise_error
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe '#export_image_diff', :docker do
     let(:images) { [] }
     let(:output) { StringIO.new }


### PR DESCRIPTION
This will be a minor version bump to 4.1.

When `dockly` builds images to be imported from S3, it tags them as `repo:latest`. With registry builds, it was leaving them as `serveraddress/repo:gitsha`, which made it difficult for consumers with complicated build pipelines to predict how to load the image. **This PR standardizes the tag strategy to `repo:latest` for images stored in registries as well as S3.**

Also, in the previous version, if registry authentication succeeded but pushing the image failed, `dockly` would not raise an error. This meant that CI relying on `dockly` could build green without the image actually pushing to the registry. **Failure to push to a registry now results in an error raising.**
