### PR TITLE
Support newer AWS cli

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,6 +14,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,30 @@
+name: Unit Tests
+on: [push, pull_request]
+jobs:
+  docker-rspec:
+    runs-on:
+      - ubuntu-18.04
+    strategy:
+      matrix:
+        ruby:
+          - 2.7
+          - 2.6
+          - 2.5
+          - 2.4
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: install bundler
+        run: |
+          gem install bundler -v '~> 1.17.3'
+          bundle update
+      - name: install rpm
+        run: |
+          set -x
+          sudo apt-get update -y
+          sudo apt-get install -y rpm
+      - name: spec tests
+        run: CI=true bundle exec rake

--- a/dockly.gemspec
+++ b/dockly.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'aws-sdk-s3', '~> 1'
   gem.add_dependency 'aws-sdk-ecr', '~> 1'
   gem.add_dependency 'foreman'
-  gem.add_dependency 'fpm', '~> 1.2.0'
+  gem.add_dependency 'fpm', '~> 1.2'
   gem.add_dependency 'minigit', '~> 0.0.4'
   gem.add_development_dependency 'cane'
   gem.add_development_dependency 'pry'

--- a/lib/dockly/rpm.rb
+++ b/lib/dockly/rpm.rb
@@ -31,5 +31,6 @@ private
     @deb_package.attributes[:rpm_user] = "root"
     @deb_package.attributes[:rpm_group] = "root"
     @deb_package.attributes[:rpm_os] = os
+    @deb_package.attributes[:workdir] = ::Dir.tmpdir
   end
 end

--- a/snippets/auth_ecr.erb
+++ b/snippets/auth_ecr.erb
@@ -1,5 +1,8 @@
 auth_ecr() {
-  $(aws ecr get-login --region us-east-1 --no-include-email)
+  account_id=$(aws sts get-caller-identity --query Account --output text)
+  region="<%= ENV['AWS_REGION'] || 'us-east-1' %>"
+  aws ecr get-login-password --region $region | \
+    docker login --username AWS --password-stdin $account_id.dkr.ecr.$region.amazonaws.com
 }
 
 worked=1


### PR DESCRIPTION
AWS has changed the way the CLI works and removed an older method of logging into the ECR.

Since `dockly` builds the snippets to login to the ECR if we're using it, we should upgrade it to the latest form, especially since the old method has now been removed from the latest AWS CLI.