### PR TITLE
Remove requirement for an SSH agent

### DIFF
--- a/lib/dockly/history.rb
+++ b/lib/dockly/history.rb
@@ -8,7 +8,6 @@ module Dockly::History
   TAG_PREFIX = 'dockly-'
 
   def push_content_tag!
-    fail 'An SSH agent must be running to push the tag' if ENV['SSH_AUTH_SOCK'].nil?
     refs = ["refs/tags/#{content_tag}"]
     remotes = repo.capturing.remote(:v => true).split(/\n/).map{ |r| r.split.first }.uniq
     remotes.each do |remote|


### PR DESCRIPTION
__Problem__

We don't need to run an agent if the SSH config is already set up.

__Solution__

Remove agent requirement.

__Impact__

No change.

__Backout Plan__

Roll forward.